### PR TITLE
Adds skip row callback

### DIFF
--- a/lib/xlsx_reader.ex
+++ b/lib/xlsx_reader.ex
@@ -182,8 +182,21 @@ defmodule XlsxReader do
     * `blank_value` - placeholder value for empty cells (default: `""`)
     * `empty_rows` - include empty rows (default: `true`)
     * `number_type` - type used for numeric conversion :`Integer`, `Decimal` or `Float` (default: `Float`)
+    * `skip_row?`: function callback that determines if a row should be skipped or not.
+       Overwrites `blank_value` and `empty_rows` on the matter of skipping rows.
+       Defaults to `nil` (keeping the behaviour of `blank_value` and `empty_rows`).
 
   The `Decimal` type requires the [decimal](https://github.com/ericmj/decimal) library.
+
+  ## Examples
+
+  ### Skipping rows
+
+  ```elixir
+  XlsxReader.sheet(package, "Sheet1", skip_row?: fn row -> Enum.all(row, & &1 == "-") end)
+  XlsxReader.sheet(package, "Sheet1", skip_row?: fn row -> Enum.all(row, & String.trim(&1) == "") end)
+  XlsxReader.sheet(package, "Sheet1", skip_row?: fn row -> Enum.at(row, 0) == "disabled" end)
+  ```
 
   """
   @spec sheet(XlsxReader.Package.t(), sheet_name(), Keyword.t()) :: {:ok, rows()}

--- a/lib/xlsx_reader/parsers/worksheet_parser.ex
+++ b/lib/xlsx_reader/parsers/worksheet_parser.ex
@@ -22,7 +22,8 @@ defmodule XlsxReader.Parsers.WorksheetParser do
               type_conversion: nil,
               blank_value: nil,
               empty_rows: nil,
-              number_type: nil
+              number_type: nil,
+              skip_row?: nil
   end
 
   @doc """
@@ -42,7 +43,8 @@ defmodule XlsxReader.Parsers.WorksheetParser do
       type_conversion: Keyword.get(options, :type_conversion, true),
       blank_value: Keyword.get(options, :blank_value, ""),
       empty_rows: Keyword.get(options, :empty_rows, true),
-      number_type: Keyword.get(options, :number_type, Float)
+      number_type: Keyword.get(options, :number_type, Float),
+      skip_row?: Keyword.get(options, :skip_row?)
     })
   end
 
@@ -141,6 +143,10 @@ defmodule XlsxReader.Parsers.WorksheetParser do
         cell_type: nil,
         value: nil
     }
+  end
+
+  defp skip_row?(%{skip_row?: skip_row?, row: row}) when is_function(skip_row?) do
+    skip_row?.(row)
   end
 
   defp skip_row?(state) do

--- a/lib/xlsx_reader/parsers/worksheet_parser.ex
+++ b/lib/xlsx_reader/parsers/worksheet_parser.ex
@@ -35,6 +35,9 @@ defmodule XlsxReader.Parsers.WorksheetParser do
     * `blank_value`: placeholder value for empty cells (default: `""`)
     * `empty_rows`: include empty rows (default: `true`)
     * `number_type` - type used for numeric conversion : `String` (no conversion), `Integer`, 'Decimal' or `Float`  (default: `Float`)
+    * `skip_row?`: function callback that determines if a row should be skipped or not.
+       Overwrites `blank_value` and `empty_rows` on the matter of skipping rows.
+       Defaults to `nil` (keeping the behaviour of `blank_value` and `empty_rows`).
 
   """
   def parse(xml, workbook, options \\ []) do

--- a/test/fixtures/package/xl/sharedStrings.xml
+++ b/test/fixtures/package/xl/sharedStrings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sst uniqueCount="20" xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<sst uniqueCount="22" xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
   <si>
     <t>A</t>
   </si>
@@ -67,5 +67,11 @@
       </rPr>
       <t>https://elixir-lang.org/</t>
     </r>
+  </si>
+  <si>
+    <t xml:space="preserve"> </t>
+  </si>
+  <si>
+    <t xml:space="preserve">-</t>
   </si>
 </sst>

--- a/test/fixtures/package/xl/worksheets/sheet4.xml
+++ b/test/fixtures/package/xl/worksheets/sheet4.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+    <sheetPr filterMode="false">
+        <pageSetUpPr fitToPage="false" />
+    </sheetPr>
+    <dimension ref="A1:D2" />
+    <sheetViews>
+        <sheetView showFormulas="false" showGridLines="true" showRowColHeaders="true" showZeros="true" rightToLeft="false" tabSelected="true" showOutlineSymbols="true" defaultGridColor="true" view="normal" topLeftCell="A1" colorId="64" zoomScale="100" zoomScaleNormal="100" zoomScalePageLayoutView="100" workbookViewId="0">
+            <selection pane="topLeft" activeCell="E1" activeCellId="0" sqref="E1" />
+        </sheetView>
+    </sheetViews>
+    <sheetFormatPr defaultColWidth="11.53515625" defaultRowHeight="12.8" zeroHeight="false" outlineLevelRow="0" outlineLevelCol="0"></sheetFormatPr>
+    <sheetData>
+        <row r="1" customFormat="false" ht="12.8" hidden="false" customHeight="false" outlineLevel="0" collapsed="false">
+            <c r="A1" s="0" t="s">
+                <v>20</v>
+            </c>
+            <c r="B1" s="0" t="s">
+                <v>20</v>
+            </c>
+            <c r="C1" s="0" t="s">
+                <v>20</v>
+            </c>
+            <c r="D1" s="0" t="s">
+                <v>20</v>
+            </c>
+        </row>
+        <row r="2" customFormat="false" ht="12.8" hidden="false" customHeight="false" outlineLevel="0" collapsed="false">
+            <c r="A2" s="0" t="s">
+                <v>21</v>
+            </c>
+            <c r="B2" s="0" t="s">
+                <v>21</v>
+            </c>
+            <c r="C2" s="0" t="s">
+                <v>21</v>
+            </c>
+            <c r="D2" s="0" t="s">
+                <v>21</v>
+            </c>
+        </row>
+    </sheetData>
+    <printOptions headings="false" gridLines="false" gridLinesSet="true" horizontalCentered="false" verticalCentered="false" />
+    <pageMargins left="0.7875" right="0.7875" top="1.05277777777778" bottom="1.05277777777778" header="0.7875" footer="0.7875" />
+    <pageSetup paperSize="9" scale="100" firstPageNumber="1" fitToWidth="1" fitToHeight="1" pageOrder="downThenOver" orientation="portrait" blackAndWhite="false" draft="false" cellComments="none" useFirstPageNumber="true" horizontalDpi="300" verticalDpi="300" copies="1" />
+    <headerFooter differentFirst="false" differentOddEven="false">
+        <oddHeader>&amp;C&amp;&quot;Times New Roman,Regular&quot;&amp;12&amp;A</oddHeader>
+        <oddFooter>&amp;C&amp;&quot;Times New Roman,Regular&quot;&amp;12Página &amp;P</oddFooter>
+    </headerFooter>
+</worksheet>

--- a/test/xlsx_reader/parsers/shared_strings_parser_test.exs
+++ b/test/xlsx_reader/parsers/shared_strings_parser_test.exs
@@ -28,7 +28,9 @@ defmodule XlsxReader.Parsers.SharedStringsParserTest do
         "ticked",
         "not ticked",
         "hyperlink",
-        "https://elixir-lang.org/"
+        "https://elixir-lang.org/",
+        " ",
+        "-"
       ])
 
     assert {:ok, expected} == SharedStringsParser.parse(shared_strings_xml)

--- a/test/xlsx_reader/parsers/worksheet_parser_test.exs
+++ b/test/xlsx_reader/parsers/worksheet_parser_test.exs
@@ -92,4 +92,22 @@ defmodule XlsxReader.Parsers.WorksheetParserTest do
 
     assert expected == rows
   end
+
+  test "should ignore rows based on skip_row?", %{
+    workbook: workbook
+  } do
+    sheet_xml = TestFixtures.read!("package/xl/worksheets/sheet4.xml")
+
+    ignore_trimmed = fn row -> Enum.all?(row, & String.trim(&1) == "") end
+
+    assert {:ok, rows} = WorksheetParser.parse(sheet_xml, workbook, skip_row?: ignore_trimmed)
+    assert [["-", "-", "-", "-"]] == rows
+
+    ignore_trimmed_or_dashes = fn row -> ignore_trimmed.(row) or Enum.all?(row, & &1 == "-") end
+
+    assert {:ok, rows} = WorksheetParser.parse(sheet_xml, workbook, skip_row?: ignore_trimmed_or_dashes)
+    assert [] == rows
+  end
+
+
 end


### PR DESCRIPTION
Adds a skip_row callback in order to skip rows when still parsing the xlsx, saving some memory before giving the final result.

Why I needed this...
Some xlsx that I have to parse are stored in gdocs and they are downloaded locally and then uploaded into our system.
I don't know if is a gdocs error or editors messing some stuff, but some files are huge, even though they have only 200 usefull lines, other ones being empty `""` or even empty spaces `"   "`.
So `empty_rows` and `blank_value` didn't work for me.

When parsing without this PR, a 5mb file (200 usefull lines) would result in almos 1M lines, almost 2gb of memory and a crash at heroku dyno. With this change, the parsing only took the 200 lines that mattered and kept memory stable without huge peaks.

Why not just filter after...
It could be done, code was already prepared for this scenario, but the amount of memory that it was taking was crashing the server, without reaching the filtering code.