### PR TITLE
Migrate GitHub Actions to erlef/setup-beam

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,15 +8,14 @@ jobs:
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
-        otp: ["22", "23", "24"]
+        otp: ["22", "23", "24", "25"]
         elixir: ["1.10.4", "1.11.4", "1.12.3", "1.13.4"]
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-elixir@v1
+    - uses: erlef/setup-beam@v1
       with:
         otp-version: ${{matrix.otp}}
         elixir-version: ${{matrix.elixir}}
-        experimental-otp: true
     - name: Install dependencies
       run: mix deps.get
     - name: Run tests


### PR DESCRIPTION
See https://github.com/erlef/setup-beam/issues/20

We also bump to latest OTP 25.