### PR TITLE
Remove BOM from extracted files.

### DIFF
--- a/lib/xlsx_reader/zip_archive.ex
+++ b/lib/xlsx_reader/zip_archive.ex
@@ -45,7 +45,7 @@ defmodule XlsxReader.ZipArchive do
   def extract(zip_handle, file) do
     with {:ok, zip} <- source(zip_handle),
          {:ok, [{_, contents}]} <- :zip.extract(zip, extract_options(file)) do
-      {:ok, contents}
+      {:ok, remove_bom(contents)}
     else
       {:ok, []} ->
         {:error, "file #{inspect(file)} not found in archive"}
@@ -56,6 +56,10 @@ defmodule XlsxReader.ZipArchive do
   end
 
   ##
+
+  def remove_bom(str) when is_binary(str) do
+    str |> String.trim_leading("\uFEFF")
+  end
 
   defp source({:path, path}) do
     {:ok, String.to_charlist(path)}


### PR DESCRIPTION
Had problems with XLSX files written by a C# library called EEPlus. It put BOM chars at the start of all xml files in the xlsx package and caused Saxy to fail parsing.
This should take care of that.