### PR TITLE
Fix XlsxReader.sheet/3 Credo pattern match error

### DIFF
--- a/lib/xlsx_reader.ex
+++ b/lib/xlsx_reader.ex
@@ -207,7 +207,7 @@ defmodule XlsxReader do
   ```
 
   """
-  @spec sheet(XlsxReader.Package.t(), sheet_name(), Keyword.t()) :: {:ok, rows()}
+  @spec sheet(XlsxReader.Package.t(), sheet_name(), Keyword.t()) :: {:ok, rows()} | error()
   def sheet(package, sheet_name, options \\ []) do
     PackageLoader.load_sheet_by_name(package, sheet_name, options)
   end


### PR DESCRIPTION
The function `XlsxReader.sheet/3` causes a Credo pattern match error since `PackageLoader.load_sheet_by_name/3` can return an `XlsxReader.error()` struct and includes it in its spec.