### PR TITLE
Catch translate_zip_error when code is :eisdir

### DIFF
--- a/lib/xlsx_reader/zip_archive.ex
+++ b/lib/xlsx_reader/zip_archive.ex
@@ -92,7 +92,7 @@ defmodule XlsxReader.ZipArchive do
   end
 
   defp translate_zip_error({:error, code})
-       when code in [:einval, :bad_eocd, :bad_central_directory] do
+       when code in [:einval, :bad_eocd, :bad_central_directory, :eisdir] do
     {:error, "invalid zip file"}
   end
 end

--- a/test/xlsx_reader_test.exs
+++ b/test/xlsx_reader_test.exs
@@ -45,6 +45,14 @@ defmodule XlsxReaderTest do
       assert {:error, "invalid zip file"} = XlsxReader.open(xlsx)
     end
 
+    test "rejects relative and absolute path to directory" do
+      relative_path = "test"
+      absolute_path = Path.absname(relative_path)
+
+      assert {:error, "invalid zip file"} = XlsxReader.open(relative_path)
+      assert {:error, "invalid zip file"} = XlsxReader.open(absolute_path)
+    end
+
     test "supported custom formats" do
       xlsx = TestFixtures.path("test.xlsx")
 


### PR DESCRIPTION
I had a `test.xlsx` file in the root directory of my project and omitted the extension by mistake when testing `open/3` in iex.

The test fails on master branch with:
```
 1) test open/2 rejects relative and absolute path to directory (XlsxReaderTest)
     test/xlsx_reader_test.exs:48
     ** (FunctionClauseError) no function clause matching in XlsxReader.ZipArchive.translate_zip_error/1

     The following arguments were given to XlsxReader.ZipArchive.translate_zip_error/1:
     
         # 1
         {:error, :eisdir}
     
     Attempted function clauses (showing 2 out of 2):
     
         defp translate_zip_error({:error, :enoent})
         defp translate_zip_error({:error, code}) when code === :einval or code === :bad_eocd or code === :bad_central_directory
     
     code: assert {:error, "invalid zip file"} = XlsxReader.open(relative_path)
```

Not sure if you want to handle this with the "invalid zip file" error or create a new one for "path is directory"?