### PR TITLE
Add support for shared formulas

### DIFF
--- a/lib/xlsx_reader/array.ex
+++ b/lib/xlsx_reader/array.ex
@@ -8,6 +8,10 @@ defmodule XlsxReader.Array do
     :array.from_list(list, nil)
   end
 
+  def insert(array, index, value) do
+    :array.set(index, value, array)
+  end
+
   def lookup(array, index, default \\ nil) do
     case :array.get(index, array) do
       :undefined ->

--- a/lib/xlsx_reader/parsers/worksheet_parser.ex
+++ b/lib/xlsx_reader/parsers/worksheet_parser.ex
@@ -22,6 +22,8 @@ defmodule XlsxReader.Parsers.WorksheetParser do
               cell_style: nil,
               value: nil,
               formula: nil,
+              shared_formula_string_index: nil,
+              shared_formulas: %{},
               type_conversion: nil,
               blank_value: nil,
               empty_rows: nil,
@@ -103,8 +105,17 @@ defmodule XlsxReader.Parsers.WorksheetParser do
     {:ok, expect_value(state)}
   end
 
-  def handle_event(:start_element, {"f", _attributes}, state) do
-    {:ok, expect_formula(state)}
+  def handle_event(:start_element, {"f", attributes}, state) do
+    attributes = attributes |> Map.new()
+
+    case attributes do
+      %{"t" => "shared", "ref" => _, "si" => string_index} ->
+        state = state |> store_shared_formula(string_index) |> expect_shared_formula()
+        {:ok, state}
+
+      _ ->
+        {:ok, expect_formula(state)}
+    end
   end
 
   @impl Saxy.Handler
@@ -115,6 +126,12 @@ defmodule XlsxReader.Parsers.WorksheetParser do
   @impl Saxy.Handler
   def handle_event(:end_element, "c", state) do
     {:ok, add_cell_to_row(state)}
+  end
+
+  @impl Saxy.Handler
+  def handle_event(:end_element, "f", %{formula: nil} = state) do
+    formula = lookup_shared_formula(state, state.shared_formula_string_index)
+    {:ok, store_formula(state, formula)}
   end
 
   @impl Saxy.Handler
@@ -147,6 +164,12 @@ defmodule XlsxReader.Parsers.WorksheetParser do
   end
 
   @impl Saxy.Handler
+  def handle_event(:characters, chars, %{value: :expect_shared_formula} = state) do
+    state = store_shared_formula(state, state.shared_formula_string_index, chars)
+    {:ok, store_formula(state, chars)}
+  end
+
+  @impl Saxy.Handler
   def handle_event(:characters, _chars, state) do
     {:ok, state}
   end
@@ -169,12 +192,21 @@ defmodule XlsxReader.Parsers.WorksheetParser do
     %{state | value: :expect_formula}
   end
 
+  defp expect_shared_formula(state) do
+    %{state | value: :expect_shared_formula}
+  end
+
   defp store_value(state, value) do
     %{state | value: value}
   end
 
   defp store_formula(state, formula) do
     %{state | formula: formula}
+  end
+
+  defp store_shared_formula(state, string_index, formula \\ nil) do
+    shared_formulas = state.shared_formulas |> Map.put(string_index, formula)
+    %{state | shared_formulas: shared_formulas, shared_formula_string_index: string_index}
   end
 
   defp add_cell_to_row(state) do
@@ -360,6 +392,12 @@ defmodule XlsxReader.Parsers.WorksheetParser do
   defp lookup_shared_string(state, value) do
     lookup_index(state.workbook.shared_strings, value)
   end
+
+  defp lookup_shared_formula(state, string_index) do
+    state.shared_formulas |> Map.get(string_index, "")
+  end
+
+  defp lookup_index(nil, _string_index), do: nil
 
   defp lookup_index(table, string_index) do
     {:ok, index} = Conversion.to_integer(string_index)

--- a/lib/xlsx_reader/parsers/worksheet_parser.ex
+++ b/lib/xlsx_reader/parsers/worksheet_parser.ex
@@ -106,10 +106,12 @@ defmodule XlsxReader.Parsers.WorksheetParser do
   end
 
   def handle_event(:start_element, {"f", attributes}, state) do
-    attributes = attributes |> Map.new()
+    type = Utils.get_attribute(attributes, "t")
+    ref = Utils.get_attribute(attributes, "ref")
+    string_index = Utils.get_attribute(attributes, "si")
 
-    case attributes do
-      %{"t" => "shared", "ref" => _, "si" => string_index} ->
+    case {type, ref, string_index} do
+      {"shared", ref, string_index} when is_binary(ref) ->
         state = state |> expect_shared_formula(string_index)
         {:ok, state}
 

--- a/test/fixtures/xml/worhseetWithSharedFormulas.xml
+++ b/test/fixtures/xml/worhseetWithSharedFormulas.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+	<sheetData>
+		<row r="1" spans="1:2" x14ac:dyDescent="0.2">
+			<c r="A1">
+				<v>
+					1
+				</v>
+			</c>
+			<c r="B1">
+				<f t="shared" ref="" si="0">
+					SUM(A1:A3)
+				</f>
+				<v>
+					6
+				</v>
+			</c>
+		</row>
+		<row r="2" spans="1:2" x14ac:dyDescent="0.2">
+			<c r="A2">
+				<v>
+					2
+				</v>
+			</c>
+			<c r="B2">
+				<f t="shared" si="0" />
+				<v>
+					6
+				</v>
+			</c>
+		</row>
+		<row r="3" spans="1:2" x14ac:dyDescent="0.2">
+			<c r="A3">
+				<v>
+					3
+				</v>
+			</c>
+			<c r="B3">
+				<f t="shared" si="0" />
+				<v>
+					6
+				</v>
+			</c>
+		</row>
+	</sheetData>
+</worksheet>

--- a/test/xlsx_reader/parsers/worksheet_parser_test.exs
+++ b/test/xlsx_reader/parsers/worksheet_parser_test.exs
@@ -137,6 +137,7 @@ defmodule XlsxReader.Parsers.WorksheetParserTest do
     assert expected == sheets
   end
 
+  @tag runnable: true
   test "should return shared formulas as part of Cell struct", %{workbook: workbook} do
     sheet_xml =
       TestFixtures.read!("xml/worhseetWithSharedFormulas.xml")

--- a/test/xlsx_reader/parsers/worksheet_parser_test.exs
+++ b/test/xlsx_reader/parsers/worksheet_parser_test.exs
@@ -136,4 +136,28 @@ defmodule XlsxReader.Parsers.WorksheetParserTest do
 
     assert expected == sheets
   end
+
+  test "should return shared formulas as part of Cell struct", %{workbook: workbook} do
+    sheet_xml =
+      TestFixtures.read!("xml/worhseetWithSharedFormulas.xml")
+      |> String.replace("\n", "")
+      |> String.replace("\t", "")
+
+    expected = [
+      [
+        %XlsxReader.Cell{value: "1", formula: nil, ref: "A1"},
+        %XlsxReader.Cell{value: "6", formula: "SUM(A1:A3)", ref: "B1"}
+      ],
+      [
+        %XlsxReader.Cell{value: "2", formula: nil, ref: "A2"},
+        %XlsxReader.Cell{value: "6", formula: "SUM(A1:A3)", ref: "B2"}
+      ],
+      [
+        %XlsxReader.Cell{value: "3", formula: nil, ref: "A3"},
+        %XlsxReader.Cell{value: "6", formula: "SUM(A1:A3)", ref: "B3"}
+      ]
+    ]
+
+    assert {:ok, expected} == WorksheetParser.parse(sheet_xml, workbook, cell_data_format: :cell)
+  end
 end


### PR DESCRIPTION
### Changes
Adds support for extracting "shared formulas" from xlsx files, when using `cell_data_format: :cell`

### Details
As an optimization technique, excel will extract the formula string from cells with the same formula and flag it as a "shared formula". Subsequent cells can reference this formula by its `string index`.

Shared formulas are stored in the same xml file as the worksheet, not in a separate file like styles or shared strings.
For example:
```xml
<!-- first use of formula defines the shared value -->
<f t="shared" ref="" si="0">
    SUM(A1:A3)
</f>

<!-- subsequent uses just reference it with si, f-tag is empty-->
<f t="shared" ref="" si="0" />
```
