### PR TITLE
Strip leading byte-order marker from parsers

### DIFF
--- a/lib/xlsx_reader/parsers/relationships_parser.ex
+++ b/lib/xlsx_reader/parsers/relationships_parser.ex
@@ -11,7 +11,9 @@ defmodule XlsxReader.Parsers.RelationshipsParser do
   @behaviour Saxy.Handler
 
   def parse(xml) do
-    Saxy.parse_string(xml, __MODULE__, %{
+    xml
+    |> Utils.strip_leading_bom()
+    |> Saxy.parse_string(__MODULE__, %{
       shared_strings: %{},
       styles: %{},
       themes: %{},

--- a/lib/xlsx_reader/parsers/shared_strings_parser.ex
+++ b/lib/xlsx_reader/parsers/shared_strings_parser.ex
@@ -23,7 +23,9 @@ defmodule XlsxReader.Parsers.SharedStringsParser do
   end
 
   def parse(xml) do
-    Saxy.parse_string(xml, __MODULE__, %State{})
+    xml
+    |> Utils.strip_leading_bom()
+    |> Saxy.parse_string(__MODULE__, %State{})
   end
 
   @impl Saxy.Handler

--- a/lib/xlsx_reader/parsers/styles_parser.ex
+++ b/lib/xlsx_reader/parsers/styles_parser.ex
@@ -21,6 +21,8 @@ defmodule XlsxReader.Parsers.StylesParser do
   end
 
   def parse(xml, supported_custom_formats \\ []) do
+    xml = Utils.strip_leading_bom(xml)
+
     with {:ok, state} <-
            Saxy.parse_string(xml, __MODULE__, %State{
              supported_custom_formats: supported_custom_formats

--- a/lib/xlsx_reader/parsers/utils.ex
+++ b/lib/xlsx_reader/parsers/utils.ex
@@ -101,4 +101,19 @@ defmodule XlsxReader.Parsers.Utils do
         {:error, "incomplete UTF-16 binary"}
     end
   end
+
+  @doc """
+  A valid Excel document could contain a leading BOM (Byte-order marker). Saxy fails to parse
+  xml documents where the leading character is not `<`.
+
+  ## Examples
+
+      iex> XlsxReader.Parsers.Utils.strip_leading_bom("\uFEFF<xml />")
+      "<xml />"
+
+      iex> XlsxReader.Parsers.Utils.strip_leading_bom("<xml />")
+      "<xml />"
+  """
+  @spec strip_leading_bom(String.t()) :: String.t()
+  def strip_leading_bom(xml), do: String.replace_leading(xml, "\uFEFF", "")
 end

--- a/lib/xlsx_reader/parsers/workbook_parser.ex
+++ b/lib/xlsx_reader/parsers/workbook_parser.ex
@@ -21,7 +21,9 @@ defmodule XlsxReader.Parsers.WorkbookParser do
   def parse(xml, options \\ []) do
     exclude_hidden_sheets? = Keyword.get(options, :exclude_hidden_sheets?, false)
 
-    Saxy.parse_string(xml, __MODULE__, %XlsxReader.Workbook{
+    xml
+    |> Utils.strip_leading_bom()
+    |> Saxy.parse_string(__MODULE__, %XlsxReader.Workbook{
       options: %{exclude_hidden_sheets?: exclude_hidden_sheets?}
     })
   end

--- a/lib/xlsx_reader/parsers/worksheet_parser.ex
+++ b/lib/xlsx_reader/parsers/worksheet_parser.ex
@@ -48,7 +48,9 @@ defmodule XlsxReader.Parsers.WorksheetParser do
 
   """
   def parse(xml, workbook, options \\ []) do
-    Saxy.parse_string(xml, __MODULE__, %State{
+    xml
+    |> Utils.strip_leading_bom()
+    |> Saxy.parse_string(__MODULE__, %State{
       workbook: workbook,
       type_conversion: Keyword.get(options, :type_conversion, true),
       blank_value: Keyword.get(options, :blank_value, ""),

--- a/test/xlsx_reader/parsers/relationships_parser_test.exs
+++ b/test/xlsx_reader/parsers/relationships_parser_test.exs
@@ -25,4 +25,9 @@ defmodule XlsxReader.Parsers.RelationshipsParserTest do
 
     assert {:ok, expected} == RelationshipsParser.parse(workbook_xml_rels)
   end
+
+  test "parses strings with leading BOM" do
+    workbook_xml_rels = TestFixtures.read!("package/xl/_rels/workbook.xml.rels")
+    assert {:ok, _} = RelationshipsParser.parse("\uFEFF" <> workbook_xml_rels)
+  end
 end

--- a/test/xlsx_reader/parsers/shared_strings_parser_test.exs
+++ b/test/xlsx_reader/parsers/shared_strings_parser_test.exs
@@ -51,6 +51,11 @@ defmodule XlsxReader.Parsers.SharedStringsParserTest do
     assert {:ok, expected} == SharedStringsParser.parse(shared_strings_xml)
   end
 
+  test "parses strings with leading BOM" do
+    shared_strings_xml = TestFixtures.read!("xml/sharedStringsWithRichText.xml")
+    assert {:ok, _} = SharedStringsParser.parse("\uFEFF" <> shared_strings_xml)
+  end
+
   test "takes xml:space instruction into account" do
     shared_strings_xml = TestFixtures.read!("xml/sharedStringsWithXmlSpacePreserve.xml")
 

--- a/test/xlsx_reader/parsers/workbook_parser_test.exs
+++ b/test/xlsx_reader/parsers/workbook_parser_test.exs
@@ -20,4 +20,9 @@ defmodule XlsxReader.Parsers.WorkbookParserTest do
 
     assert {:ok, expected} == WorkbookParser.parse(workbook_xml)
   end
+
+  test "parses strings with leading BOM" do
+    workbook_xml = TestFixtures.read!("package/xl/workbook.xml")
+    assert {:ok, _} = WorkbookParser.parse("\uFEFF" <> workbook_xml)
+  end
 end

--- a/test/xlsx_reader/parsers/worksheet_parser_test.exs
+++ b/test/xlsx_reader/parsers/worksheet_parser_test.exs
@@ -172,4 +172,9 @@ defmodule XlsxReader.Parsers.WorksheetParserTest do
     visible_sheet_names = package |> XlsxReader.sheet_names()
     assert visible_sheet_names == ["Sheet 1"]
   end
+
+  test "parses strings with leading BOM", %{workbook: workbook} do
+    sheet_xml = TestFixtures.read!("package/xl/worksheets/sheet1.xml")
+    assert {:ok, _result} = WorksheetParser.parse("\uFEFF" <> sheet_xml, workbook)
+  end
 end


### PR DESCRIPTION
Hello 👋

Some valid XML excel files might start with a special character (a leading BOM), this PR fixes parsing for this scenario.

Thanks!