### PR TITLE
Accept option to exclude empty sheets

### DIFF
--- a/lib/xlsx_reader/parsers/workbook_parser.ex
+++ b/lib/xlsx_reader/parsers/workbook_parser.ex
@@ -17,12 +17,20 @@ defmodule XlsxReader.Parsers.WorkbookParser do
 
   ## Options
     * `:exclude_hidden_sheets?` - Whether to exclude hidden sheets in the workbook
+    * `:exclude_empty_sheets?` - Whether to exclude empty sheets in the workbook
+    * `:preload_sheets?` - Whether to preload all workbook sheets on open
   """
   def parse(xml, options \\ []) do
+    exclude_empty_sheets? = Keyword.get(options, :exclude_empty_sheets?, false)
     exclude_hidden_sheets? = Keyword.get(options, :exclude_hidden_sheets?, false)
+    preload_sheets? = exclude_empty_sheets? or Keyword.get(options, :preload_sheets?, false)
 
     Saxy.parse_string(xml, __MODULE__, %XlsxReader.Workbook{
-      options: %{exclude_hidden_sheets?: exclude_hidden_sheets?}
+      options: %{
+        exclude_empty_sheets?: exclude_empty_sheets?,
+        exclude_hidden_sheets?: exclude_hidden_sheets?,
+        preload_sheets?: preload_sheets?
+      }
     })
   end
 

--- a/lib/xlsx_reader/parsers/worksheet_parser.ex
+++ b/lib/xlsx_reader/parsers/worksheet_parser.ex
@@ -73,7 +73,7 @@ defmodule XlsxReader.Parsers.WorksheetParser do
   def handle_event(:start_element, {"row", attributes}, state) do
     # Some XLSX writers (Excel, Elixlsx, …) completely omit `<row>` or `<c>` elements when empty.
     # As we build the sheet, we'll keep track of the expected row and column number and
-    # fill the blanks as needed usingthe coordinates indicated in the row or cell reference.
+    # fill the blanks as needed using the coordinates indicated in the row or cell reference.
 
     current_row =
       case Utils.get_attribute(attributes, "r") do

--- a/lib/xlsx_reader/sheet.ex
+++ b/lib/xlsx_reader/sheet.ex
@@ -3,17 +3,18 @@ defmodule XlsxReader.Sheet do
 
   Worksheet structure.
 
-  This structure only contains the information useful to identify and retrieve the sheet actual data.
+  This structure contains initially only the information useful to identify and retrieve the sheet actual data.
 
   - `name` - name of the sheet
   - `rid` - relationship ID used to retrieve the corresponding sheet in the archive
   - `sheet_id` - unique identifier of the sheet withing the workbook (unused by XlsxReader)
+  - `data` - `nil` or a list of rows if sheet was loaded
 
   To access the sheet cells, see `XlsxReader.sheet/3` and `XlsxReader.sheets/2`.
 
   """
 
-  defstruct [:name, :rid, :sheet_id]
+  defstruct [:name, :rid, :sheet_id, :data]
 
   @typedoc """
   XLSX worksheet metadata
@@ -21,6 +22,7 @@ defmodule XlsxReader.Sheet do
   @type t :: %__MODULE__{
           name: String.t(),
           rid: String.t(),
-          sheet_id: String.t()
+          sheet_id: String.t(),
+          data: nil | [XlsxReader.row()]
         }
 end


### PR DESCRIPTION
Hi @xavier 👋

While testing new Livebook feature to accept drag and drop of excel files with `XlsxReader`, I've got to some issues with empty sheets, and `:expect_chars` handling.

[José Valim suggested](https://github.com/livebook-dev/livebook/pull/2577#discussion_r1579395773) on two possible improvements to `XlsxReader`, in this PR I have a proof of concept for skipping empty sheets.

This turned out a bit trickier than I've thought, hehe... 

As open doesn't extract and parses all sheets in advance, we couldn't exclude empty sheets unless we eagerly preload them on open.

What do you think?

Thanks!

cc https://github.com/livebook-dev/livebook/issues/2580