### PR TITLE
Transform remaining :expect_chars after parse into empty string

### DIFF
--- a/lib/xlsx_reader/parsers/worksheet_parser.ex
+++ b/lib/xlsx_reader/parsers/worksheet_parser.ex
@@ -247,13 +247,21 @@ defmodule XlsxReader.Parsers.WorksheetParser do
 
   defp emit_row(state) do
     state = handle_omitted_rows(state)
+    row = state.row |> sanitize_row() |> Enum.reverse()
 
     %{
       state
       | row: nil,
-        rows: [Enum.reverse(state.row) | state.rows],
+        rows: [row | state.rows],
         expected_row: state.current_row + 1
     }
+  end
+
+  defp sanitize_row(row) do
+    Enum.map(row, fn
+      :expect_chars -> nil
+      value -> value
+    end)
   end
 
   defp restore_rows_order(state) do

--- a/lib/xlsx_reader/parsers/worksheet_parser.ex
+++ b/lib/xlsx_reader/parsers/worksheet_parser.ex
@@ -259,7 +259,7 @@ defmodule XlsxReader.Parsers.WorksheetParser do
 
   defp sanitize_row(row) do
     Enum.map(row, fn
-      :expect_chars -> nil
+      :expect_chars -> ""
       value -> value
     end)
   end

--- a/test/fixtures/package/xl/worksheets/sheet5.xml
+++ b/test/fixtures/package/xl/worksheets/sheet5.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheetPr>
+    <pageSetUpPr fitToPage="1"/>
+  </sheetPr>
+  <dimension ref="A1:E1"/>
+  <sheetViews>
+    <sheetView defaultGridColor="1" showGridLines="0" workbookViewId="0"/>
+  </sheetViews>
+  <sheetFormatPr customHeight="1" defaultColWidth="16.3333" defaultRowHeight="19.9" outlineLevelCol="0" outlineLevelRow="0"/>
+  <cols>
+    <col customWidth="1" max="1" min="1" style="17" width="16.3516"/>
+    <col customWidth="1" max="2" min="2" style="17" width="22.7734"/>
+    <col customWidth="1" max="256" min="3" style="17" width="16.3516"/>
+  </cols>
+  <sheetData>
+    <row customHeight="1" ht="20.25" r="1">
+      <c r="A1" s="10"/>
+      <c r="B1" t="inlineStr"><is><t></t></is></c>
+      <c r="C1" t="inlineStr"><is><t>Hello</t></is></c>
+      <c r="D1"></c>
+      <c r="E1" t="n"><v>0.0</v></c>
+    </row>
+  </sheetData>
+  <pageMargins bottom="1" footer="0.25" header="0.25" left="1" right="1" top="1"/>
+  <pageSetup firstPageNumber="1" fitToHeight="1" fitToWidth="1" orientation="portrait" pageOrder="downThenOver" scale="100" useFirstPageNumber="0"/>
+  <headerFooter>
+    <oddFooter>&amp;C&amp;&quot;Helvetica Neue,Regular&quot;&amp;12&amp;K000000&amp;P</oddFooter>
+  </headerFooter>
+</worksheet>

--- a/test/xlsx_reader/parsers/worksheet_parser_test.exs
+++ b/test/xlsx_reader/parsers/worksheet_parser_test.exs
@@ -83,6 +83,13 @@ defmodule XlsxReader.Parsers.WorksheetParserTest do
     assert expected == rows
   end
 
+  test "handles correctly empty values", %{workbook: workbook} do
+    sheet_xml = TestFixtures.read!("package/xl/worksheets/sheet5.xml")
+
+    assert {:ok, [["", "", "Hello", "", "0.0"]]} =
+             WorksheetParser.parse(sheet_xml, workbook, type_conversion: false)
+  end
+
   test "handles inline strings", %{workbook: workbook} do
     sheet_xml = TestFixtures.read!("xml/worksheetWithInlineStr.xml")
 


### PR DESCRIPTION
Some empty cells don't seem to hit this line on the parser:

```elixir
  @impl Saxy.Handler
  def handle_event(:characters, chars, %{value: :expect_chars} = state) do
    {:ok, store_value(state, chars)}
  end
```

Then the value of the cell remains `:expect_chars` after parse. 

With this PR we remove any lingering `:expect_chars` and make it `""`. Not sure if same could happen with `:expect_formula`.

Thanks!

cc https://github.com/livebook-dev/livebook/issues/2580