### PR TITLE
Transform remaining :expect_formula after parse into empty string

### DIFF
--- a/lib/xlsx_reader/parsers/worksheet_parser.ex
+++ b/lib/xlsx_reader/parsers/worksheet_parser.ex
@@ -262,6 +262,7 @@ defmodule XlsxReader.Parsers.WorksheetParser do
       # If the <c> element has no text child node, we didn't receive any :characters event
       # and the current value still contains the placeholder used by the parser
       :expect_chars -> ""
+      :expect_formula -> ""
       # Otherwise assume that the row contains an actual value
       value -> value
     end)


### PR DESCRIPTION
Hi @xavier 👋

I'm getting also [that problem](https://github.com/xavier/xlsx_reader/pull/30) but with `:expect_formula`.

```elixir
Integer.parse(:expect_formula, 10)

FunctionClauseError: no function clause matching in Integer.parse/2
  File "lib/integer.ex", line 275, in Integer.parse/2
  File "lib/xlsx_reader/conversion.ex", line 187, in XlsxReader.Conversion.to_integer/1
  File "lib/xlsx_reader/parsers/worksheet_parser.ex", line 437, in XlsxReader.Parsers.WorksheetParser.lookup_index/2
  File "lib/xlsx_reader/parsers/worksheet_parser.ex", line 333, in XlsxReader.Parsers.WorksheetParser.format_cell_data/1
  File "lib/xlsx_reader/parsers/worksheet_parser.ex", line 224, in XlsxReader.Parsers.WorksheetParser.add_cell_to_row/1
  File "lib/xlsx_reader/parsers/worksheet_parser.ex", line 129, in XlsxReader.Parsers.WorksheetParser.handle_event/3
  File "lib/saxy/emitter.ex", line 16, in Saxy.Emitter.emit/3
  File "lib/saxy/emitter.ex", line 7, in Saxy.Emitter.emit/4
```

I don't have the file locally to reproduce, but I think this should fix it.

Thanks!