### PR TITLE
relax `:saxy` dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule XlsxReader.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:saxy, "~> 1.5.0"},
+      {:saxy, "~> 1.5"},
       {:credo, "~> 1.4.0", only: [:dev, :test], runtime: false},
       {:decimal, "~> 1.0 or ~> 2.0", optional: true},
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false},


### PR DESCRIPTION
Having a too specific version of `:saxy` as requirement prevents projects depending on `:xlsx_reader` from updating `:saxy` to its latest version.
According to [Elixir's Library guidelines](https://hexdocs.pm/elixir/main/library-guidelines.html#dependency-version-requirements), libraries should avoid being too specific on their dependencies version.

Relax Saxy version, from `~> 1.5.0` to `~> 1.5`.
