### PR TITLE
Add additional common date formats to styles

### DIFF
--- a/lib/xlsx_reader/styles.ex
+++ b/lib/xlsx_reader/styles.ex
@@ -91,7 +91,7 @@ defmodule XlsxReader.Styles do
     {"0.0%", :percentage},
     {~r/\Add?\/mm?\/yy(?:yy)\z/, :date},
     {~r/\Add?\/mm?\/yy(?:yy) hh?:mm?\z/, :date_time},
-    {"yyyy-mm-dd", :date},
+    {~r/\Ay+(\\\/|-)m+(\\\/|-)d+\z/i, :date},
     {~r/\Ayyyy-mm-dd[T\s]hh?:mm:ssZ?\z/, :date_time},
     {"m/d/yyyy", :date},
     {"m/d/yyyy h:mm", :date_time},

--- a/test/xlsx_reader/styles_test.exs
+++ b/test/xlsx_reader/styles_test.exs
@@ -26,6 +26,11 @@ defmodule XlsxReader.StylesTest do
       assert :date = Styles.get_style_type("123", %{"123" => "m/d/yyyy"})
       assert :date_time = Styles.get_style_type("123", %{"123" => "m/d/yyyy h:mm"})
 
+      # Alternative date formats
+      assert :date = Styles.get_style_type("123", %{"123" => "yyyy\\/mm\\/dd"})
+      assert :date = Styles.get_style_type("123", %{"123" => "yy\\/m\\/d"})
+      assert :date = Styles.get_style_type("123", %{"123" => "yy-m-d"})
+
       # Plain time
       assert :time = Styles.get_style_type("123", %{"123" => "hh:mm"})
     end


### PR DESCRIPTION
We found that some of the date formats we deal with does not show as :date. 

This makes the matching on non-us formats a bit more liberal, but should not conclude to false positives either. 