### PR TITLE
fix: handle formulas without cached result

### DIFF
--- a/lib/xlsx_reader/parsers/worksheet_parser.ex
+++ b/lib/xlsx_reader/parsers/worksheet_parser.ex
@@ -210,7 +210,7 @@ defmodule XlsxReader.Parsers.WorksheetParser do
   end
 
   defp store_formula(state, formula) do
-    %{state | formula: formula}
+    %{state | formula: formula, value: nil}
   end
 
   defp store_shared_formula(state, index, formula) do
@@ -262,7 +262,6 @@ defmodule XlsxReader.Parsers.WorksheetParser do
       # If the <c> element has no text child node, we didn't receive any :characters event
       # and the current value still contains the placeholder used by the parser
       :expect_chars -> ""
-      :expect_formula -> ""
       # Otherwise assume that the row contains an actual value
       value -> value
     end)

--- a/test/fixtures/xml/worksheetWithFormulasWithoutValue.xml
+++ b/test/fixtures/xml/worksheetWithFormulasWithoutValue.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+	<sheetData>
+		<row r="1" spans="1:2" x14ac:dyDescent="0.2">
+			<c r="A1">
+				<v>
+					1
+				</v>
+			</c>
+			<c r="B1">
+				<f>
+					SUM(A1:A3)
+				</f>
+			</c>
+		</row>
+	</sheetData>
+</worksheet>

--- a/test/fixtures/xml/worksheetWithSharedFormulasWithoutValue.xml
+++ b/test/fixtures/xml/worksheetWithSharedFormulasWithoutValue.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+	<sheetData>
+		<row r="1" spans="1:2" x14ac:dyDescent="0.2">
+			<c r="A1">
+				<v>
+					1
+				</v>
+			</c>
+			<c r="B1">
+				<f t="shared" ref="" si="0">
+					SUM(A1:A3)
+				</f>
+			</c>
+		</row>
+		<row r="2" spans="1:2" x14ac:dyDescent="0.2">
+			<c r="A2">
+				<v>
+					2
+				</v>
+			</c>
+			<c r="B2">
+				<f t="shared" si="0" />
+			</c>
+		</row>
+		<row r="3" spans="1:2" x14ac:dyDescent="0.2">
+			<c r="A3">
+				<v>
+					3
+				</v>
+			</c>
+			<c r="B3">
+				<f t="shared" si="0" />
+			</c>
+		</row>
+	</sheetData>
+</worksheet>

--- a/test/xlsx_reader/parsers/worksheet_parser_test.exs
+++ b/test/xlsx_reader/parsers/worksheet_parser_test.exs
@@ -144,6 +144,22 @@ defmodule XlsxReader.Parsers.WorksheetParserTest do
     assert expected == sheets
   end
 
+  test "should return empty value when result of formulas is not set", %{workbook: workbook} do
+    sheet_xml =
+      TestFixtures.read!("xml/worksheetWithFormulasWithoutValue.xml")
+      |> String.replace("\n", "")
+      |> String.replace("\t", "")
+
+    expected = [
+      [
+        %Cell{value: "1", formula: nil, ref: "A1"},
+        %Cell{value: "", formula: "SUM(A1:A3)", ref: "B1"}
+      ]
+    ]
+
+    assert {:ok, expected} == WorksheetParser.parse(sheet_xml, workbook, cell_data_format: :cell)
+  end
+
   test "should return shared formulas as part of Cell struct", %{workbook: workbook} do
     sheet_xml =
       TestFixtures.read!("xml/worksheetWithSharedFormulas.xml")
@@ -166,6 +182,36 @@ defmodule XlsxReader.Parsers.WorksheetParserTest do
     ]
 
     assert {:ok, expected} == WorksheetParser.parse(sheet_xml, workbook, cell_data_format: :cell)
+  end
+
+  test "should return empty value when result of shared formulas is not set", %{
+    workbook: workbook
+  } do
+    sheet_xml =
+      TestFixtures.read!("xml/worksheetWithSharedFormulasWithoutValue.xml")
+      |> String.replace("\n", "")
+      |> String.replace("\t", "")
+
+    expected = [
+      [
+        %XlsxReader.Cell{value: "1", formula: nil, ref: "A1"},
+        %XlsxReader.Cell{value: "", formula: "SUM(A1:A3)", ref: "B1"}
+      ],
+      [
+        %XlsxReader.Cell{value: "2", formula: nil, ref: "A2"},
+        %XlsxReader.Cell{value: "", formula: "SUM(A1:A3)", ref: "B2"}
+      ],
+      [
+        %XlsxReader.Cell{value: "3", formula: nil, ref: "A3"},
+        %XlsxReader.Cell{value: "", formula: "SUM(A1:A3)", ref: "B3"}
+      ]
+    ]
+
+    assert {:ok, expected} ==
+             WorksheetParser.parse(sheet_xml, workbook,
+               cell_data_format: :cell,
+               type_conversion: true
+             )
   end
 
   test "should include or exclude hidden sheets based on an option" do


### PR DESCRIPTION
Hi @xavier 

When `<v>` is not specified after a formula and a style is specified an error like the following occurs:

```elixir
** (FunctionClauseError) no function clause matching in Float.parse_unsigned/1

The following arguments were given to Float.parse_unsigned/1:

    # 1
    :expect_formula

Attempted function clauses (showing 2 out of 2):

    defp parse_unsigned(<<digit, rest::binary>>) when is_integer(digit) and digit >= 48 and digit <= 57
    defp parse_unsigned(binary) when is_binary(binary)
```

Instead, if no style is specified, the cell value returned is `:expect_formula`

