### PR TITLE
expand error handling for XlsxReader.Conversion.to_number/2

### DIFF
--- a/lib/xlsx_reader/conversion.ex
+++ b/lib/xlsx_reader/conversion.ex
@@ -75,24 +75,29 @@ defmodule XlsxReader.Conversion do
       iex> XlsxReader.Conversion.to_number("123.0", Integer)
       :error
 
+      iex> XlsxReader.Conversion.to_number(:not_a_string, Integer)
+      :error
+
   """
   @spec to_number(String.t(), number_type()) :: {:ok, number_value()} | :error
 
-  def to_number(string, Integer) do
+  def to_number(string, Integer) when is_binary(string) do
     to_integer(string)
   end
 
-  def to_number(string, Float) do
+  def to_number(string, Float) when is_binary(string) do
     to_float(string)
   end
 
-  def to_number(string, Decimal) do
+  def to_number(string, Decimal) when is_binary(string) do
     to_decimal(string)
   end
 
-  def to_number(string, String) do
+  def to_number(string, String) when is_binary(string) do
     {:ok, string}
   end
+
+  def to_number(_, _), do: :error
 
   @doc """
 


### PR DESCRIPTION
When trying to parse the .xlsx file from https://www.simplify.us/sites/default/files/excel_holdings/2025_08_22_Simplify_Portfolio_EOD_Tracker.xlsx, then 
```
path = "https://www.simplify.us/sites/default/files/excel_holdings/2025_08_22_Simplify_Portfolio_EOD_Tracker.xlsx"

with {:ok, package} <- XlsxReader.open(path),
     {:ok, rows} = XlsxReader.sheet(package, "Simplify Portfolio Tracker") do
  {:ok, rows}
else
  e -> {:error, e}
end
```
causes `XlsxReader.Conversion.to_number/2` to receive `:expected_chars` as a value (passed down from `saxy` it seems like), which causes an unhandled exception. This PR changes this so an `:error` is returned in these cases instead.