### PR TITLE
Allow :decimal ~> 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule XlsxReader.MixProject do
     [
       {:saxy, "~> 1.5"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
-      {:decimal, "~> 1.0 or ~> 2.0", optional: true},
+      {:decimal, "~> 1.0 or ~> 2.0 or ~> 3.0", optional: true},
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false},
       {:ex_doc, "~> 0.22", only: :dev, runtime: false},
       {:elixlsx, "~> 0.4.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
Pinning the `:decimal` library makes it so that users of the library are currently unable to use the most recent version of the library without  using overrides (which cannot be published to hex).